### PR TITLE
Add theme and settings page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,11 @@
             <button id="clearHistoryBtn">Clear</button>
         </div>
     </div>
-    <div id="settingsPage">
+    <div id="settingsPage" style="display: none">
         <h2>Settings</h2>
         <label class="toggle"><input type="checkbox" id="darkModeToggle" /><span class="slider"></span><span>Dark mode</span></label>
-        <label>Circle size: <input type="number" id="circleSizeInput" min="20" max="120" step="5" />
-            <span id="circlePreview" class="preview-circle"></span></label>
-        <label>Circle color: <input type="color" id="circleColorInput" /></label>
+        <label><span id="circlePreview" class="preview-circle"></span> Circle size: <input type="number" id="circleSizeInput" min="20" max="120" step="5" /></label>
+        <label><input type="color" id="circleColorInput" /> Circle color</label>
         <button id="saveSettingsBtn">Save</button>
         <button id="backBtn">Back</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -31,8 +31,10 @@
         </div>
         <div class="setting-row">
             <span>Circle size</span>
-            <span id="circlePreview" class="preview-circle"></span>
             <input type="number" id="circleSizeInput" min="20" max="120" step="5" />
+        </div>
+        <div class="preview-area">
+            <span id="circlePreview" class="preview-circle"></span>
         </div>
         <button id="saveSettingsBtn">Save</button>
         <button id="backBtn">Back</button>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     </div>
     <div id="settingsPage">
         <h2>Settings</h2>
-        <label><input type="checkbox" id="darkModeToggle" /> Dark mode</label>
+        <label class="toggle"><input type="checkbox" id="darkModeToggle" /><span class="slider"></span><span>Dark mode</span></label>
         <label>Circle size: <input type="number" id="circleSizeInput" min="20" max="120" step="5" />
             <span id="circlePreview" class="preview-circle"></span></label>
         <label>Circle color: <input type="color" id="circleColorInput" /></label>

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
     <div id="settingsPage" style="display: none">
         <h2>Settings</h2>
         <label class="toggle"><input type="checkbox" id="darkModeToggle" /><span class="slider"></span><span>Dark mode</span></label>
-        <label><span id="circlePreview" class="preview-circle"></span> Circle size: <input type="number" id="circleSizeInput" min="20" max="120" step="5" /></label>
         <label><input type="color" id="circleColorInput" /> Circle color</label>
+        <label><span id="circlePreview" class="preview-circle"></span> Circle size: <input type="number" id="circleSizeInput" min="20" max="120" step="5" /></label>
         <button id="saveSettingsBtn">Save</button>
         <button id="backBtn">Back</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -12,11 +12,19 @@
     <div id="menu">
         <h1>Mouseless Aim</h1>
         <button id="startBtn">Start</button>
+        <button id="settingsBtn" class="icon-btn" title="Settings">⚙️</button>
         <div id="historyArea">
             <h2>History</h2>
             <ul id="historyList"></ul>
             <button id="clearHistoryBtn">Clear</button>
         </div>
+    </div>
+    <div id="settingsPage">
+        <h2>Settings</h2>
+        <label><input type="checkbox" id="darkModeToggle" /> Dark mode</label>
+        <label>Circle size: <input type="number" id="circleSizeInput" min="20" max="120" step="5" /></label>
+        <button id="saveSettingsBtn">Save</button>
+        <button id="backBtn">Back</button>
     </div>
     <button id="stopBtn" style="display: none">Stop</button>
     <div id="scoreHud" style="display: none">

--- a/index.html
+++ b/index.html
@@ -22,7 +22,9 @@
     <div id="settingsPage">
         <h2>Settings</h2>
         <label><input type="checkbox" id="darkModeToggle" /> Dark mode</label>
-        <label>Circle size: <input type="number" id="circleSizeInput" min="20" max="120" step="5" /></label>
+        <label>Circle size: <input type="number" id="circleSizeInput" min="20" max="120" step="5" />
+            <span id="circlePreview" class="preview-circle"></span></label>
+        <label>Circle color: <input type="color" id="circleColorInput" /></label>
         <button id="saveSettingsBtn">Save</button>
         <button id="backBtn">Back</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -21,9 +21,19 @@
     </div>
     <div id="settingsPage" style="display: none">
         <h2>Settings</h2>
-        <label class="toggle"><input type="checkbox" id="darkModeToggle" /><span class="slider"></span><span>Dark mode</span></label>
-        <label><input type="color" id="circleColorInput" /> Circle color</label>
-        <label><span id="circlePreview" class="preview-circle"></span> Circle size: <input type="number" id="circleSizeInput" min="20" max="120" step="5" /></label>
+        <div class="setting-row">
+            <span>Dark mode</span>
+            <label class="toggle"><input type="checkbox" id="darkModeToggle" /><span class="slider"></span></label>
+        </div>
+        <div class="setting-row">
+            <span>Circle color</span>
+            <input type="color" id="circleColorInput" />
+        </div>
+        <div class="setting-row">
+            <span>Circle size</span>
+            <span id="circlePreview" class="preview-circle"></span>
+            <input type="number" id="circleSizeInput" min="20" max="120" step="5" />
+        </div>
         <button id="saveSettingsBtn">Save</button>
         <button id="backBtn">Back</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -18,6 +18,27 @@ const backBtn = document.getElementById("backBtn");
 const saveSettingsBtn = document.getElementById("saveSettingsBtn");
 const darkModeToggle = document.getElementById("darkModeToggle");
 const circleSizeInput = document.getElementById("circleSizeInput");
+const circleColorInput = document.getElementById("circleColorInput");
+const circlePreview = document.getElementById("circlePreview");
+
+darkModeToggle.onchange = () => {
+    if (darkModeToggle.checked) {
+        document.body.classList.add("theme-nord");
+        localStorage.setItem("theme", "nord");
+    } else {
+        document.body.classList.remove("theme-nord");
+        localStorage.setItem("theme", "light");
+    }
+};
+
+circleSizeInput.oninput = () => {
+    updateCirclePreview();
+};
+
+circleColorInput.oninput = () => {
+    circleColor = circleColorInput.value;
+    applyCircleColor();
+};
 
 let prevTimestamp = null;
 let times = [];
@@ -27,11 +48,23 @@ let timerInterval = null;
 let startTime = null;
 let isRunning = false;
 let circleSize = 60;
+let circleColor = "#84cc16";
 
 function applyCircleSize() {
     target.style.width = circleSize + "px";
     target.style.height = circleSize + "px";
     document.documentElement.style.setProperty("--circle-size", circleSize + "px");
+}
+
+function applyCircleColor() {
+    document.documentElement.style.setProperty("--custom-target-color", circleColor);
+    circlePreview.style.background = circleColor;
+    circlePreview.style.borderColor = circleColor;
+}
+
+function updateCirclePreview() {
+    circlePreview.style.width = circleSizeInput.value + "px";
+    circlePreview.style.height = circleSizeInput.value + "px";
 }
 
 // safe margin from all borders
@@ -166,6 +199,7 @@ clearHistoryBtn.onclick = () => {
 settingsBtn.onclick = () => {
     menu.style.display = "none";
     settingsPage.style.display = "";
+    loadSettings();
 };
 
 backBtn.onclick = () => {
@@ -184,20 +218,20 @@ function loadSettings() {
     }
     circleSize = parseInt(localStorage.getItem("circleSize") || "60");
     circleSizeInput.value = circleSize;
+    circleColor = localStorage.getItem("circleColor") || circleColor;
+    circleColorInput.value = circleColor;
     applyCircleSize();
+    applyCircleColor();
+    updateCirclePreview();
 }
 
 saveSettingsBtn.onclick = () => {
-    if (darkModeToggle.checked) {
-        document.body.classList.add("theme-nord");
-        localStorage.setItem("theme", "nord");
-    } else {
-        document.body.classList.remove("theme-nord");
-        localStorage.setItem("theme", "light");
-    }
     circleSize = parseInt(circleSizeInput.value) || 60;
     localStorage.setItem("circleSize", circleSize);
+    circleColor = circleColorInput.value || circleColor;
+    localStorage.setItem("circleColor", circleColor);
     applyCircleSize();
+    applyCircleColor();
     backBtn.click();
 };
 

--- a/script.js
+++ b/script.js
@@ -12,6 +12,12 @@ const historyList = document.getElementById("historyList");
 const clearHistoryBtn = document.getElementById("clearHistoryBtn");
 const menu = document.getElementById("menu");
 const scoreHud = document.getElementById("scoreHud");
+const settingsBtn = document.getElementById("settingsBtn");
+const settingsPage = document.getElementById("settingsPage");
+const backBtn = document.getElementById("backBtn");
+const saveSettingsBtn = document.getElementById("saveSettingsBtn");
+const darkModeToggle = document.getElementById("darkModeToggle");
+const circleSizeInput = document.getElementById("circleSizeInput");
 
 let prevTimestamp = null;
 let times = [];
@@ -20,12 +26,19 @@ let timer = 0;
 let timerInterval = null;
 let startTime = null;
 let isRunning = false;
+let circleSize = 60;
+
+function applyCircleSize() {
+    target.style.width = circleSize + "px";
+    target.style.height = circleSize + "px";
+    document.documentElement.style.setProperty("--circle-size", circleSize + "px");
+}
 
 // safe margin from all borders
 const margin = 70; // should be > radius+border
 
 function randomPos() {
-    const targetSize = 60 + 4 * 2; // circle + border
+    const targetSize = circleSize + 4 * 2; // circle + border
     const w = window.innerWidth;
     const h = window.innerHeight;
     const minX = margin;
@@ -71,6 +84,7 @@ startBtn.onclick = () => {
     minTimeSpan.textContent = "-";
     maxTimeSpan.textContent = "-";
     target.style.display = "";
+    applyCircleSize();
     randomPos();
     isRunning = true;
     timer = 0;
@@ -149,11 +163,58 @@ clearHistoryBtn.onclick = () => {
     loadHistory();
 };
 
+settingsBtn.onclick = () => {
+    menu.style.display = "none";
+    settingsPage.style.display = "";
+};
+
+backBtn.onclick = () => {
+    settingsPage.style.display = "none";
+    menu.style.display = "";
+};
+
+function loadSettings() {
+    const theme = localStorage.getItem("theme");
+    if (theme === "nord") {
+        document.body.classList.add("theme-nord");
+        darkModeToggle.checked = true;
+    } else {
+        document.body.classList.remove("theme-nord");
+        darkModeToggle.checked = false;
+    }
+    circleSize = parseInt(localStorage.getItem("circleSize") || "60");
+    circleSizeInput.value = circleSize;
+    applyCircleSize();
+}
+
+saveSettingsBtn.onclick = () => {
+    if (darkModeToggle.checked) {
+        document.body.classList.add("theme-nord");
+        localStorage.setItem("theme", "nord");
+    } else {
+        document.body.classList.remove("theme-nord");
+        localStorage.setItem("theme", "light");
+    }
+    circleSize = parseInt(circleSizeInput.value) || 60;
+    localStorage.setItem("circleSize", circleSize);
+    applyCircleSize();
+    backBtn.click();
+};
+
 document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && isRunning) stopGame();
+    if (e.key === "Escape") {
+        if (settingsPage.style.display !== "none") {
+            backBtn.click();
+        } else if (isRunning) {
+            stopGame();
+        }
+    }
 });
 
-window.onload = loadHistory;
+window.onload = () => {
+    loadHistory();
+    loadSettings();
+};
 
 // Optional: keyboard trigger for target
 document.addEventListener("keydown", (e) => {

--- a/script.js
+++ b/script.js
@@ -50,6 +50,13 @@ let isRunning = false;
 let circleSize = 60;
 let circleColor = "#84cc16";
 
+function adjustColor(col, factor) {
+    const r = Math.min(255, Math.max(0, Math.round(parseInt(col.slice(1, 3), 16) * factor)));
+    const g = Math.min(255, Math.max(0, Math.round(parseInt(col.slice(3, 5), 16) * factor)));
+    const b = Math.min(255, Math.max(0, Math.round(parseInt(col.slice(5, 7), 16) * factor)));
+    return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
 function applyCircleSize() {
     target.style.width = circleSize + "px";
     target.style.height = circleSize + "px";
@@ -57,9 +64,11 @@ function applyCircleSize() {
 }
 
 function applyCircleColor() {
+    const border = adjustColor(circleColor, 1.1);
     document.documentElement.style.setProperty("--custom-target-color", circleColor);
+    document.documentElement.style.setProperty("--custom-target-border", border);
     circlePreview.style.background = circleColor;
-    circlePreview.style.borderColor = circleColor;
+    circlePreview.style.borderColor = border;
 }
 
 function updateCirclePreview() {

--- a/script.js
+++ b/script.js
@@ -50,6 +50,13 @@ let isRunning = false;
 let circleSize = 60;
 let circleColor = "#84cc16";
 
+function hexToRgb(hex) {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    return { r, g, b };
+}
+
 function adjustColor(col, factor) {
     const r = Math.min(255, Math.max(0, Math.round(parseInt(col.slice(1, 3), 16) * factor)));
     const g = Math.min(255, Math.max(0, Math.round(parseInt(col.slice(3, 5), 16) * factor)));
@@ -67,6 +74,11 @@ function applyCircleColor() {
     const border = adjustColor(circleColor, 1.1);
     document.documentElement.style.setProperty("--custom-target-color", circleColor);
     document.documentElement.style.setProperty("--custom-target-border", border);
+    const rgb = hexToRgb(circleColor);
+    document.documentElement.style.setProperty(
+        "--pulse-rgb",
+        `${rgb.r}, ${rgb.g}, ${rgb.b}`,
+    );
     circlePreview.style.background = circleColor;
     circlePreview.style.borderColor = border;
 }

--- a/script.js
+++ b/script.js
@@ -29,6 +29,12 @@ darkModeToggle.onchange = () => {
         document.body.classList.remove("theme-nord");
         localStorage.setItem("theme", "light");
     }
+    if (!localStorage.getItem("circleColor")) {
+        circleColor = getComputedStyle(document.body)
+            .getPropertyValue("--target-color")
+            .trim();
+    }
+    applyCircleColor();
 };
 
 circleSizeInput.oninput = () => {
@@ -239,7 +245,11 @@ function loadSettings() {
     }
     circleSize = parseInt(localStorage.getItem("circleSize") || "60");
     circleSizeInput.value = circleSize;
-    circleColor = localStorage.getItem("circleColor") || circleColor;
+    const storedColor = localStorage.getItem("circleColor");
+    const defaultColor = getComputedStyle(document.body)
+        .getPropertyValue("--target-color")
+        .trim();
+    circleColor = storedColor || defaultColor;
     circleColorInput.value = circleColor;
     applyCircleSize();
     applyCircleColor();

--- a/style.css
+++ b/style.css
@@ -4,6 +4,7 @@
   --target-border: #85cd17; /* circle border */
   --custom-target-color: ;
   --custom-target-border: ;
+  --pulse-rgb: 132, 204, 22;
   --text-color: #706b68; /* text color */
   --hud-bg: #232946ee; /* HUD bg */
   --font-color: #232946; /* menu/font */
@@ -26,6 +27,7 @@ body.theme-nord {
   --clear-btn-color: #eceff4;
   --custom-target-color: ;
   --custom-target-border: ;
+  --pulse-rgb: 163, 190, 140;
 }
 
 body {
@@ -46,7 +48,7 @@ body {
   border-radius: 24px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   padding: 2em 3em;
-  text-align: center;
+  text-align: left;
   min-width: 350px;
 }
 
@@ -174,13 +176,13 @@ button:active {
 
 @keyframes pulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(132, 204, 22, 0.7);
+    box-shadow: 0 0 0 0 rgba(var(--pulse-rgb), 0.7);
   }
   70% {
-    box-shadow: 0 0 0 15px rgba(132, 204, 22, 0);
+    box-shadow: 0 0 0 15px rgba(var(--pulse-rgb), 0);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(132, 204, 22, 0);
+    box-shadow: 0 0 0 0 rgba(var(--pulse-rgb), 0);
   }
 }
 
@@ -193,7 +195,7 @@ button:active {
   border-radius: 24px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   padding: 2em 3em;
-  text-align: center;
+  text-align: left;
   min-width: 350px;
 }
 #settingsPage label {

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@
   --main-color: #c1af89; /* page bg */
   --target-color: #84cc16; /* circle */
   --target-border: #85cd17; /* circle border */
+  --custom-target-color: ;
   --text-color: #706b68; /* text color */
   --hud-bg: #232946ee; /* HUD bg */
   --font-color: #232946; /* menu/font */
@@ -22,6 +23,7 @@ body.theme-nord {
   --history-bg: #434c5e;
   --clear-btn-bg: #4c566a;
   --clear-btn-color: #eceff4;
+  --custom-target-color: ;
 }
 
 body {
@@ -159,11 +161,11 @@ button:active {
   width: var(--circle-size, 60px);
   height: var(--circle-size, 60px);
   border-radius: 50%;
-  background: var(--target-color);
+  background: var(--custom-target-color, var(--target-color));
   box-shadow: 0 4px 24px #84cc1688;
   cursor: pointer;
   z-index: 1000;
-  border: 4px solid var(--target-border);
+  border: 4px solid var(--custom-target-color, var(--target-border));
   transition: box-shadow 0.2s;
   animation: pulse 1.5s infinite;
 }
@@ -199,6 +201,16 @@ button:active {
 }
 #settingsPage input[type="number"] {
   width: 80px;
+}
+#settingsPage .preview-circle {
+  display: inline-block;
+  margin-left: 0.6em;
+  vertical-align: middle;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--custom-target-color, var(--target-color));
+  border: 4px solid var(--custom-target-color, var(--target-border));
 }
 
 .icon-btn {

--- a/style.css
+++ b/style.css
@@ -25,9 +25,6 @@ body.theme-nord {
   --history-bg: #434c5e;
   --clear-btn-bg: #4c566a;
   --clear-btn-color: #eceff4;
-  --custom-target-color: ;
-  --custom-target-border: ;
-  --pulse-rgb: 163, 190, 140;
 }
 
 body {
@@ -198,8 +195,10 @@ button:active {
   text-align: left;
   min-width: 350px;
 }
-#settingsPage label {
-  display: block;
+#settingsPage .setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin: 1em 0;
 }
 #settingsPage input[type="number"] {
@@ -207,8 +206,8 @@ button:active {
 }
 #settingsPage .toggle {
   display: flex;
+  flex-direction: row-reverse;
   align-items: center;
-  justify-content: flex-start;
   gap: 0.5em;
 }
 #settingsPage .toggle input {
@@ -243,7 +242,7 @@ button:active {
 }
 #settingsPage .preview-circle {
   display: inline-block;
-  margin-right: 0.6em;
+  margin-left: 0.6em;
   vertical-align: middle;
   width: 40px;
   height: 40px;
@@ -253,7 +252,7 @@ button:active {
 }
 
 #settingsPage input[type="color"] {
-  margin-right: 0.6em;
+  margin-left: 0.6em;
   vertical-align: middle;
 }
 

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
   --target-color: #84cc16; /* circle */
   --target-border: #85cd17; /* circle border */
   --custom-target-color: ;
+  --custom-target-border: ;
   --text-color: #706b68; /* text color */
   --hud-bg: #232946ee; /* HUD bg */
   --font-color: #232946; /* menu/font */
@@ -24,6 +25,7 @@ body.theme-nord {
   --clear-btn-bg: #4c566a;
   --clear-btn-color: #eceff4;
   --custom-target-color: ;
+  --custom-target-border: ;
 }
 
 body {
@@ -165,7 +167,7 @@ button:active {
   box-shadow: 0 4px 24px #84cc1688;
   cursor: pointer;
   z-index: 1000;
-  border: 4px solid var(--custom-target-color, var(--target-border));
+  border: 4px solid var(--custom-target-border, var(--target-border));
   transition: box-shadow 0.2s;
   animation: pulse 1.5s infinite;
 }
@@ -202,6 +204,42 @@ button:active {
 #settingsPage input[type="number"] {
   width: 80px;
 }
+#settingsPage .toggle {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.5em;
+}
+#settingsPage .toggle input {
+  display: none;
+}
+#settingsPage .toggle .slider {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  background: #ccc;
+  border-radius: 24px;
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+#settingsPage .toggle .slider::before {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s;
+}
+#darkModeToggle:checked + .slider {
+  background: var(--custom-target-color, var(--target-color));
+}
+#darkModeToggle:checked + .slider::before {
+  transform: translateX(18px);
+}
 #settingsPage .preview-circle {
   display: inline-block;
   margin-left: 0.6em;
@@ -210,7 +248,7 @@ button:active {
   height: 40px;
   border-radius: 50%;
   background: var(--custom-target-color, var(--target-color));
-  border: 4px solid var(--custom-target-color, var(--target-border));
+  border: 4px solid var(--custom-target-border, var(--target-border));
 }
 
 .icon-btn {

--- a/style.css
+++ b/style.css
@@ -5,6 +5,23 @@
   --text-color: #706b68; /* text color */
   --hud-bg: #232946ee; /* HUD bg */
   --font-color: #232946; /* menu/font */
+  --menu-bg: #fffbe9;
+  --history-bg: #fffaeb;
+  --clear-btn-bg: #e7d9b9;
+  --clear-btn-color: #a08b58;
+}
+
+body.theme-nord {
+  --main-color: #2e3440;
+  --target-color: #a3be8c;
+  --target-border: #88c0d0;
+  --text-color: #eceff4;
+  --hud-bg: #3b4252ee;
+  --font-color: #eceff4;
+  --menu-bg: #3b4252;
+  --history-bg: #434c5e;
+  --clear-btn-bg: #4c566a;
+  --clear-btn-color: #eceff4;
 }
 
 body {
@@ -21,7 +38,7 @@ body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: #fffbe9;
+  background: var(--menu-bg);
   border-radius: 24px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   padding: 2em 3em;
@@ -99,7 +116,7 @@ button:active {
 
 #historyArea {
   margin-top: 2em;
-  background: #fffaeb;
+  background: var(--history-bg);
   border-radius: 12px;
   box-shadow: 0 2px 8px #23294622;
   padding: 1em;
@@ -126,8 +143,8 @@ button:active {
 }
 #clearHistoryBtn {
   display: block;
-  background: #e7d9b9;
-  color: #a08b58;
+  background: var(--clear-btn-bg);
+  color: var(--clear-btn-color);
   font-size: 0.95em;
   margin: 0.5em auto 0;
   padding: 0.35em 1em;
@@ -139,8 +156,8 @@ button:active {
 
 #target {
   position: absolute;
-  width: 60px;
-  height: 60px;
+  width: var(--circle-size, 60px);
+  height: var(--circle-size, 60px);
   border-radius: 50%;
   background: var(--target-color);
   box-shadow: 0 4px 24px #84cc1688;
@@ -148,6 +165,49 @@ button:active {
   z-index: 1000;
   border: 4px solid var(--target-border);
   transition: box-shadow 0.2s;
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(132, 204, 22, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 15px rgba(132, 204, 22, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(132, 204, 22, 0);
+  }
+}
+
+#settingsPage {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--menu-bg);
+  border-radius: 24px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+  padding: 2em 3em;
+  text-align: center;
+  min-width: 350px;
+  display: none;
+}
+#settingsPage label {
+  display: block;
+  margin: 1em 0;
+}
+#settingsPage input[type="number"] {
+  width: 80px;
+}
+
+.icon-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.3em;
+  cursor: pointer;
+  vertical-align: middle;
+  margin-left: 0.4em;
 }
 
 @media (max-width: 600px) {
@@ -163,5 +223,9 @@ button:active {
   #stopBtn {
     right: 10px;
     top: 10px;
+  }
+  #settingsPage {
+    padding: 1em 0.2em;
+    min-width: 0;
   }
 }

--- a/style.css
+++ b/style.css
@@ -240,15 +240,18 @@ button:active {
 #darkModeToggle:checked + .slider::before {
   transform: translateX(18px);
 }
+#settingsPage .preview-area {
+  text-align: center;
+  margin-top: 1.5em;
+}
 #settingsPage .preview-circle {
   display: inline-block;
-  margin-left: 0.6em;
-  vertical-align: middle;
   width: 40px;
   height: 40px;
   border-radius: 50%;
   background: var(--custom-target-color, var(--target-color));
   border: 4px solid var(--custom-target-border, var(--target-border));
+  animation: pulse 1.5s infinite;
 }
 
 #settingsPage input[type="color"] {

--- a/style.css
+++ b/style.css
@@ -209,6 +209,12 @@ button:active {
   vertical-align: middle;
   margin-left: 0.4em;
 }
+#settingsBtn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  margin-left: 0;
+}
 
 @media (max-width: 600px) {
   #menu {
@@ -223,6 +229,11 @@ button:active {
   #stopBtn {
     right: 10px;
     top: 10px;
+  }
+  #settingsBtn {
+    top: 8px;
+    right: 8px;
+    margin-left: 0;
   }
   #settingsPage {
     padding: 1em 0.2em;

--- a/style.css
+++ b/style.css
@@ -195,7 +195,6 @@ button:active {
   padding: 2em 3em;
   text-align: center;
   min-width: 350px;
-  display: none;
 }
 #settingsPage label {
   display: block;
@@ -242,13 +241,18 @@ button:active {
 }
 #settingsPage .preview-circle {
   display: inline-block;
-  margin-left: 0.6em;
+  margin-right: 0.6em;
   vertical-align: middle;
   width: 40px;
   height: 40px;
   border-radius: 50%;
   background: var(--custom-target-color, var(--target-color));
   border: 4px solid var(--custom-target-border, var(--target-border));
+}
+
+#settingsPage input[type="color"] {
+  margin-right: 0.6em;
+  vertical-align: middle;
 }
 
 .icon-btn {


### PR DESCRIPTION
## Summary
- animate the target circle with a pulse
- add a settings page accessible from a gear icon
- allow switching to a dark Nord theme
- make circle size configurable and persistent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68537dc9a90c832e9e7a67dce4357e24